### PR TITLE
fix: cannot initialize Etc variables

### DIFF
--- a/lib/wp2txt.rb
+++ b/lib/wp2txt.rb
@@ -6,6 +6,7 @@ $: << File.join(File.dirname(__FILE__))
 require "nokogiri"
 require "parallel"
 
+require 'etc'
 require 'pp'
 require "wp2txt/article"
 require "wp2txt/utils"


### PR DESCRIPTION
wp2txt emitted error that cannot initialize variables in lib/wp2txt.rb (line 37). It seemed that Etc module was not imported.
After adding the code, it runs well.